### PR TITLE
Move linker flags to end of compiler specification to resolve build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MANDIR ?= $(PREFIX)/share/man/man1
 all: xgetres
 
 xgetres: xgetres.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $? -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $? -o $@ $(LDFLAGS)
 
 install: xgetres
 	mkdir -p $(BINDIR)


### PR DESCRIPTION
I do not know why this is failing on Ubuntu but it is.  I searched around and found other projects having the same issue and this was the fix.  